### PR TITLE
Fixed syntax error with postgress order statement.

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -43,7 +43,7 @@ class Site < ActiveRecord::Base
   end
 
   def last_updated_topics
-    topics.order(:last_posted_at => :desc)
+    topics.order("last_posted_at DESC")
   end
 
 private


### PR DESCRIPTION
On the site page (/admin/sites/1), I was getting an error from Postgress (the pg gem).

```
PG::Error: ERROR:  non-integer constant in ORDER BY
LINE 1: ....* FROM "topics"  WHERE "topics"."site_id" = 1 ORDER BY '---
                                                                   ^
: SELECT "topics".* FROM "topics"  WHERE "topics"."site_id" = 1 ORDER BY '---
:last_posted_at: :desc
'
Extracted source (around line #91):

88:   created whenever a user posts a comment with a certain topic ID.</p>
89:   
90:   <div class="topics resources list">
91:     <%= render :partial => 'admin/topics/topic', :collection => @site.last_updated_topics %>
92:   </div>
93: <% end %>
```

This fixes it.
