### PR TITLE
Fixed typos in javascript embedding code.

### DIFF
--- a/app/views/admin/help/_code.txt.erb
+++ b/app/views/admin/help/_code.txt.erb
@@ -1,9 +1,9 @@
 <script type="text/javascript" class="juvia">
 (function() {
     var options = {
-        container   : <%= escape_js_string(local_assigns[:container]) || "'(a CSS path)'" %>,
-        site_key    : <%= escape_js_string(local_assigns[:site_key]) || "'(some site key)'" %>,
-        topic_key   : <%= escape_js_string(local_assigns[:topic_key]) || "location.path" %>,
+        container   : <%= raw(escape_js_string(local_assigns[:container]) || "'(a CSS path)'") %>,
+        site_key    : <%= raw(escape_js_string(local_assigns[:site_key]) || "'(some site key)'") %>,
+        topic_key   : <%= raw(escape_js_string(local_assigns[:topic_key]) || "location.pathname") %>,
         topic_url   : location.href,
         topic_title : document.title || location.href,
         include_base: !window.Juvia,


### PR DESCRIPTION
There were a few typos in the javascript embed code snippet (admin/help/_code.txt) which were causing the embedded snippet not to work. This fixes them:
- The `container` and `site_key` were being rendered in the code snippet via erb without using `raw` or `.html_safe`, so single quotes around the keys were actually showing as `&#x27;`.
- The default `topic_key` was being generated by `location.path`, which was `undefined` on all pages where the embed code was used, because the correct property is `location.pathname`.
