### PR TITLE
Make topic key trailing-slash-insensitive.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -38,10 +38,18 @@ class Topic < ActiveRecord::Base
     end
   end
 
+  def self.alt_key(topic_key)
+    topic_key.match(/\/$/) ? topic_key.chop : "#{topic_key}/"
+  end
+
 private
   def self.find_by_site_key_and_topic_key(site_key, topic_key)
     Topic.
       where('sites.key = ? AND topics.key = ?', site_key, topic_key).
+      joins(:site).
+      first ||
+    Topic.
+      where('sites.key = ? AND topics.key = ?', site_key, alt_key(topic_key)).
       joins(:site).
       first
   end


### PR DESCRIPTION
I was having an issue where comments wouldn't show up for an article with a topic key of "/blog/some-article" if the current URL was passed to Juvia with a trailing slash ("/blog/some-article/"), which is exactly equivalent. So, I made the topic lookup fallback to a second lookup with or without a trailing slash.

In other words, if the initial lookup is without a trailing slash, and no comments are found, it'll do a second lookup with a trailing slash. And vice versa; if the initial lookup is with a trailing slash, then the second lookup will be without.

I could have implemented this as a single query with an `OR` statement:

``` ruby
where(sites_table[:key].eq(site_key).and(topics_table[:key].eq(topic_key).or(topics_table[:key].eq(alt_key(topic_key)))))
```

But I wanted it to try an exact match first, and only fallback to the alternative match if there were no results, so that the exact match gets preference. Since this is a small query that only happens asynchronously once per page, the tradeoff of having two queries instead of one is small.
