### PR TITLE
Support WordPress Multisite Comment Import

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -65,6 +65,8 @@ class Admin::CommentsController < ApplicationController
   end
 
   def import
+    options = {:table_prefix => params[:table_prefix],
+      :wp_multisite_id => params[:wp_multisite_id]}
     if Juvia::Migrators.process(
       params[:site_id],
       params[:import_type],
@@ -72,8 +74,7 @@ class Admin::CommentsController < ApplicationController
       params[:database_user],
       params[:database_password],
       params[:database_host],
-      params[:table_prefix],
-      params[:wp_multisite_id]
+      options
     )
       flash[:notice] = "Imported!"
       redirect_to(admin_comments_path)

--- a/app/views/admin/comments/new_import.html.erb
+++ b/app/views/admin/comments/new_import.html.erb
@@ -32,12 +32,12 @@
   </div>
 
   <div class="para">
-    Wordpress Table Prefix<br />
+    <%= label_tag :table_prefix %> &mdash; The Wordpress table prefix (usually 'wp_')<br />
     <%= text_field_tag :table_prefix, 'wp_' %>
   </div>
 
   <div class="para">
-    Wordpress Multisite ID<br />
+    <%= label_tag :wp_multisite_id %> &mdash; The Wordpress Multisite site ID<br />
     Leave this field empty if importing from a non-multisite install, or from the base site of a multisite install.<br />
     <%= text_field_tag :wp_multisite_id %>
   </div>

--- a/lib/juvia/migrators.rb
+++ b/lib/juvia/migrators.rb
@@ -6,11 +6,11 @@ module Juvia
       require "juvia/migrators/#{p}"
     end
 
-    def self.process(site_id, migrator, dbname, user, host='localhost', options={})
+    def self.process(site_id, migrator, dbname, user, pass, host='localhost', options={})
       migrator_class = migrator.downcase.gsub(/\s/, '_')
       raise "Not a valid import type: #{migrator_class}" unless PLATFORMS.any?{ |p| p == migrator_class }
 
-      Juvia::Migrators.const_get(migrator_class.camelize).send(:process, site_id, dbname, user, host, options)
+      Juvia::Migrators.const_get(migrator_class.camelize).send(:process, site_id, dbname, user, pass, host, options)
     end
   end
 end

--- a/lib/juvia/migrators/word_press.rb
+++ b/lib/juvia/migrators/word_press.rb
@@ -91,7 +91,7 @@ module Juvia
 
         px = options[:table_prefix]
         if !options[:wp_multisite_id].blank?
-          mspx = "_#{options[:wp_multisite_id]}"
+          mspx = "#{options[:wp_multisite_id]}_"
         else
           mspx = ''
         end
@@ -135,7 +135,7 @@ module Juvia
       def self.process_post(post, db, options)
         px = options[:table_prefix]
         if !options[:wp_multisite_id].blank?
-          mspx = "_#{options[:wp_multisite_id]}"
+          mspx = "#{options[:wp_multisite_id]}_"
         else
           mspx = ''
         end


### PR DESCRIPTION
This patch adds support for importing comments from a WordPress Multi-site setup, and also specifying the WordPress table prefix to use.
