### PR TITLE
Fix WP import so topics have the right keys

### DIFF
--- a/lib/juvia/migrators/word_press.rb
+++ b/lib/juvia/migrators/word_press.rb
@@ -154,7 +154,7 @@ module Juvia
 
         topic = Topic.lookup_or_create(
           options[:site].key,
-          "#{slug}",
+          "/#{slug}",
           title,
           topic_url.to_s
         )


### PR DESCRIPTION
The Juvia JS looks up topics using a key that it gets from `location.pathname`. For `mydomain.com/my/post`, this is `/my/post`. When the WP import script runs, it creates the keys as `mydomain.com/my/post`, meaning that the topics are not correctly fetched by the JS on each page.
