### PR TITLE
Add auto-linking to comment markdown rendering

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
   end
   
   def render_markdown(str)
-    BlueCloth.new(str, :escape_html => true, :strict_mode => false).to_html.html_safe
+    BlueCloth.new(str, :escape_html => true, :strict_mode => false, :auto_links => true).to_html.html_safe
   end
 
   def escape_js_string(str)


### PR DESCRIPTION
IME, commenters expect any raw URLs that they type to be rendered as links. Support for this is added by this patch (though I appreciate that you may have left this disabled by default as a spam prevention method).
