### PR TITLE
remove protocol from gravatar url

### DIFF
--- a/app/views/api/_comment.html.erb
+++ b/app/views/api/_comment.html.erb
@@ -9,7 +9,7 @@
 			</div>
 		<% else %>
 			<div class="juvia-avatar">
-				<img src="http://www.gravatar.com/avatar/generic?s=64"
+				<img src="//www.gravatar.com/avatar/generic?s=64"
 				width="64"
 				height="64"
 				alt="<%= comment.author_name || 'Anonymous' %>">


### PR DESCRIPTION
if parent uses https, requesting anything over http will trigger a browser warning
