### PR TITLE
Fix text mail displaying html entities

### DIFF
--- a/config/initializers/fix_text_mails.rb
+++ b/config/initializers/fix_text_mails.rb
@@ -1,0 +1,33 @@
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        def call(template)
+          if template.source.encoding_aware?
+            # First, convert to BINARY, so in case the encoding is
+            # wrong, we can still find an encoding tag
+            # (<%# encoding %>) inside the String using a regular
+            # expression
+            template_source = template.source.dup.force_encoding("BINARY")
+
+            erb = template_source.gsub(ENCODING_TAG, '')
+            encoding = $2
+
+            erb.force_encoding valid_encoding(template.source.dup, encoding)
+
+            # Always make sure we return a String in the default_internal
+            erb.encode!
+          else
+            erb = template.source.dup
+          end
+
+          self.class.erb_implementation.new(
+            erb,
+            :trim => (self.class.erb_trim_mode == "-"),
+            :escape => template.identifier =~ /\.text/ # only escape HTML templates
+          ).src
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Emails notifications sent are displaying HTML entities i.e. &#x27; instead of ' (single quote).
You could just add `raw` to the template file where needed, but I found better approach using an initializer on
http://stackoverflow.com/questions/11756304/rails-escapes-html-in-my-plain-text-mails/11763211#11763211
