### PR TITLE
Bare minimum to make project work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'cancan'
 gem 'rack'
 gem 'nokogiri', "~> 1.8.5"
 gem 'css3buttons'
+gem 'rake', '< 11.0'
 
 gem 'sass-rails'
 gem 'coffee-rails'
@@ -50,7 +51,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.0.0'
   gem 'rspec-activemodel-mocks' # for compatibility
   gem 'capybara', '~> 2.2.0', :require => false
-  gem 'capybara-webkit', :require => false
+  gem 'selenium-webdriver', :require => false
   gem 'capybara-screenshot'
   gem 'database_cleaner', :require => false
   gem 'factory_girl_rails', :require => false
@@ -65,7 +66,7 @@ end
 
 group :postgres do
   # adapter: postgresql
-  gem 'pg', :require => false
+  gem 'pg', '~> 0.15', :require => false
 end
 
 group :sqlite do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
+    childprocess (3.0.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -143,7 +144,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    pg (1.1.4)
+    pg (0.20.0)
     protected_attributes (1.1.4)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.12.2)
@@ -177,7 +178,7 @@ GEM
       activesupport (= 4.2.11.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.3.2)
+    rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -209,6 +210,7 @@ GEM
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
     ruby_dep (1.5.0)
+    rubyzip (2.3.0)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -285,6 +287,9 @@ GEM
     schema_plus_views (0.3.1)
       activerecord (~> 4.2)
       schema_plus_core (~> 1.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     shellany (0.0.1)
     spork (0.9.0.rc9)
     spring (2.0.2)
@@ -335,16 +340,18 @@ DEPENDENCIES
   launchy
   mysql2
   nokogiri (~> 1.8.5)
-  pg
+  pg (~> 0.15)
   protected_attributes
   pry
   rack
   rails (~> 4.2.11)
+  rake (< 11.0)
   rspec
   rspec-activemodel-mocks
   rspec-rails (~> 3.0.0)
   sass-rails
   schema_plus
+  selenium-webdriver
   spork (= 0.9.0.rc9)
   spring
   sqlite3
@@ -353,4 +360,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( columnal.css ie.css fixed-984px-ie.css ie6-984px.css build.css )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ Spork.prefork do
   require 'capybara/rails'
   require 'capybara/rspec'
   require 'capybara-screenshot/rspec'
-  require 'capybara-webkit'
   require 'database_cleaner'
   require 'launchy'
   require 'rspec/rails'
@@ -21,7 +20,7 @@ Spork.prefork do
   # in spec/support/ and its subdirectories.
   Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-  Capybara.javascript_driver               = :webkit
+  Capybara.javascript_driver               = :selenium_headless
   Capybara::Screenshot.autosave_on_failure = false
 
   DatabaseCleaner.logger = Rails.logger

--- a/spec/support/action_controller_workaround.rb
+++ b/spec/support/action_controller_workaround.rb
@@ -1,0 +1,14 @@
+if RUBY_VERSION >= '2.6.0'
+    if Rails.version < '5'
+        class ActionController::TestResponse < ActionDispatch::TestResponse
+            def recycle!
+                # hack to avoid MonitorMixin double-initialize error:
+                @mon_mutex_owner_object_id = nil
+                @mon_mutex = nil
+                initialize
+            end
+        end
+    else
+        puts "Monkeypatch for ActionController::TestResponse no longer needed"
+    end
+end


### PR DESCRIPTION
Basically that is changes I done to make project work in development and production modes on Ruby 2.6:
- pin `pg` and `rake` gems due to deprecations
- remove `capybara-webkit`, using `selenium-webdriver` instead (forget about webdriver, it is dead)
- add monkeypatch to prevent threading issues with specs
- add assets workaround to make it work in development mode

I think we can create release 1.0.0 (stable) after merging this in master, and from stable we can move forward. BTW specs are broken anyway, but project itself seems working fine.